### PR TITLE
Added Name to Refiners for SharePoint Search

### DIFF
--- a/src/sharepoint/search.ts
+++ b/src/sharepoint/search.ts
@@ -681,7 +681,7 @@ export interface ResultTable {
     ItemTemplateId?: string;
     Properties?: { Key: string, Value: any, ValueType: string }[];
     Table?: { Rows: { Cells: { Key: string, Value: any, ValueType: string }[] }[] };
-    Refiners?: { Entries: { RefinementCount: string; RefinementName: string; RefinementToken: string; RefinementValue: string; }[]; }[];
+    Refiners?: { Name: string; Entries: { RefinementCount: string; RefinementName: string; RefinementToken: string; RefinementValue: string; }[]; }[];
     ResultTitle?: string;
     ResultTitleUrl?: string;
     RowCount?: number;


### PR DESCRIPTION
Following #686 : Added Refiners to ResultTable for SharePoint Search;

The Name Property is added to the Refiners definition.


| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    |  - [x]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

The Name property is returned by the API. But it wasn't in the definitions.



